### PR TITLE
feat: 찜 보석함 화면 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Layout from './components/Layout/Layout';
 import Home from './pages/Home';
 import Map from './pages/Map';
 import Search from './pages/Search';
+import Favorites from './pages/Favorites';
 
 export default function App() {
   return (
@@ -10,8 +11,8 @@ export default function App() {
       <Route path="/" element={<Layout />}>
         <Route index element={<Home />} />
         <Route
-          path="recommend"
-          element={<div className="p-8">찜 페이지 (구현 예정)</div>}
+          path="favorites"
+          element={<Favorites />}
         />
         <Route path="map" element={<Map />} />
         <Route

--- a/src/components/common/BottomTab.jsx
+++ b/src/components/common/BottomTab.jsx
@@ -14,10 +14,10 @@ export default function BottomTab() {
       path: '/' 
     },
     { 
-      key: 'recommend', 
+      key: 'favorites', 
       label: '찜', 
       icon: <Heart size={22} />, 
-      path: '/recommend' 
+      path: '/favorites' 
     },
     { 
       key: 'map', 

--- a/src/components/favorites/AddCollectionModal.jsx
+++ b/src/components/favorites/AddCollectionModal.jsx
@@ -1,0 +1,67 @@
+// src/components/favorites/AddCollectionModal.jsx
+import { X } from "lucide-react";
+import { useState } from "react";
+
+export default function AddCollectionModal({ open, onClose, onSubmit }) {
+  const [name, setName] = useState("");
+  const [desc, setDesc] = useState("");
+
+  if (!open) return null;
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    onSubmit({ title: name.trim(), description: desc.trim() });
+    setName("");
+    setDesc("");
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 grid place-items-center bg-black/40">
+      <div className="w-[90%] max-w-sm rounded-xl bg-white p-5 shadow-xl">
+        {/* 헤더 */}
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-base font-semibold">새 돌멩이 보석함</h3>
+          <button
+            aria-label="닫기"
+            onClick={onClose}
+            className="rounded-full p-1 text-gray-500 hover:bg-gray-100"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium">
+              새 돌멩이 보석함 이름 <span className="text-red-500">*</span>
+            </span>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="예: 카공하기 좋은 곳"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-400"
+            />
+          </label>
+
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium">새 돌멩이 보석함 설명</span>
+            <input
+              value={desc}
+              onChange={(e) => setDesc(e.target.value)}
+              placeholder="선택 입력"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-400"
+            />
+          </label>
+
+          <button
+            type="submit"
+            className="mt-2 w-full rounded-md bg-[#3C4462] py-2 text-sm font-semibold text-white"
+          >
+            추가하기
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/favorites/CollectionCard.jsx
+++ b/src/components/favorites/CollectionCard.jsx
@@ -1,0 +1,22 @@
+// src/components/favorites/CollectionCard.jsx
+export default function CollectionCard({ title, count = 0, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      className="w-full rounded-xl bg-gray-200/70 p-3 text-left"
+    >
+      {/* 2x2 placeholder grid */}
+      <div className="grid grid-cols-2 gap-1 rounded-md bg-white/50 p-1">
+        <div className="aspect-square rounded-md bg-gray-200" />
+        <div className="aspect-square rounded-md bg-gray-200" />
+        <div className="aspect-square rounded-md bg-gray-200" />
+        <div className="aspect-square rounded-md bg-gray-200" />
+      </div>
+
+      <p className="mt-2 text-sm font-medium text-gray-800">
+        {title}
+        {count ? <span className="ml-1 text-gray-500">({count})</span> : null}
+      </p>
+    </button>
+  );
+}

--- a/src/pages/Favorites.jsx
+++ b/src/pages/Favorites.jsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { Heart, Plus, Pencil } from "lucide-react";
+import CollectionCard from "../components/favorites/CollectionCard";
+import AddCollectionModal from "../components/favorites/AddCollectionModal";
+
+export default function Favorites() {
+  // 초기 더미 데이터 (이름/카운트)
+  const [collections, setCollections] = useState([
+    { id: 1, title: "카공하기 좋은 곳", count: 3 },
+    { id: 2, title: "빙수 맛있는 곳", count: 2 },
+    { id: 3, title: "카공하기 좋은 곳", count: 0 },
+    { id: 4, title: "빙수 맛있는 곳", count: 0 },
+  ]);
+
+  const [openAdd, setOpenAdd] = useState(false);
+
+  const addCollection = ({ title, description }) => {
+    setCollections((prev) => [
+      ...prev,
+      { id: Date.now(), title, description, count: 0 },
+    ]);
+    setOpenAdd(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-white pb-24">
+      {/* 상단 네이비 헤더 */}
+      <header className="bg-[#1B2340] h-36 rounded-b-2xl flex items-center justify-center text-white">
+        <div className="w-full px-5">
+          <h1 className="text-[18px] font-semibold text-center">
+            내가 찜한 돌멩이 보석함
+          </h1>
+        </div>
+      </header>
+
+      {/* 상단 액션 영역 */}
+      <div className="-mt-4 rounded-t-2xl bg-white px-5 pb-4 pt-3">
+        <div className="flex items-center gap-2">
+          <button className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-700">
+            <Heart size={14} className="text-[#3C4462]" />
+            찜 기반 추천받기
+          </button>
+
+          <button className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-700">
+            <Pencil size={14} />
+            편집
+          </button>
+
+          <button
+            onClick={() => setOpenAdd(true)}
+            className="ml-auto inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-700"
+          >
+            <Plus size={14} />
+            추가
+          </button>
+        </div>
+      </div>
+
+      {/* 보석함 그리드 */}
+      <div className="px-5 pb-28">
+        <div className="grid grid-cols-2 gap-4">
+          {collections.map((c) => (
+            <CollectionCard
+              key={c.id}
+              title={c.title}
+              count={c.count}
+              onClick={() => {}}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* 새 보석함 추가 모달 */}
+      <AddCollectionModal
+        open={openAdd}
+        onClose={() => setOpenAdd(false)}
+        onSubmit={addCollection}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 찜 보석함(Favorites) 기본 화면 구현
- 새 보석함 추가 모달 구현

## Changes
- 찜 화면 recommend  → favorites 이름 변경
- /favorites 라우트 추가
- 컬렉션 카드 2열 그리드, 헤더 액션 버튼, 모달 상태 관리

## 체크리스트
- [x] /favorites 라우트 접속 시 화면 표시
- [x] ‘+ 추가’ 클릭 시 모달 열리고 생성 동작

