### PR TITLE
feat: 상세페이지 구현, 찜 보관함 기능 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,8 @@ import Home from './pages/Home';
 import Map from './pages/Map';
 import Search from './pages/Search';
 import Favorites from './pages/Favorites';
+import PlaceDetail from './pages/PlaceDetail'; 
+
 
 export default function App() {
   return (
@@ -26,6 +28,10 @@ export default function App() {
         <Route
           path="search"
           element={<Search/>}
+        />
+        <Route 
+          path="place/:id" 
+          element={<PlaceDetail />} 
         />
 
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/common/BottomTab.jsx
+++ b/src/components/common/BottomTab.jsx
@@ -1,6 +1,9 @@
 import { Home, Heart, MapPin, Users, User } from 'lucide-react';
 import { useNavigate, useLocation } from 'react-router-dom';
 
+import communityIcon from '/icon/community.svg';
+import myPageIcon from '/icon/myPage.svg';
+
 export default function BottomTab() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -28,13 +31,13 @@ export default function BottomTab() {
     { 
       key: 'community', 
       label: '커뮤니티', 
-      icon: <img src="icon/community.svg" alt="커뮤니티" width={22} height={22} />, 
+      icon: <img src={communityIcon} alt="커뮤니티" width={22} height={22} />,
       path: '/community' 
     },
     { 
       key: 'profile', 
       label: '내 정보', 
-      icon: <img src="icon/myPage.svg" alt="커뮤니티" width={22} height={22} />, 
+      icon: <img src={myPageIcon} alt="내 정보" width={22} height={22} />,
       path: '/profile' 
     }
   ];

--- a/src/components/common/PlaceCards.jsx
+++ b/src/components/common/PlaceCards.jsx
@@ -1,5 +1,6 @@
 import Card from './Card';
 import { useRef } from 'react';
+import { Link } from 'react-router-dom';
 
 export default function PlaceCards({ 
   places = [], 
@@ -28,17 +29,33 @@ export default function PlaceCards({
       className={`${currentLayout} ${className}`}
       onWheel={layout === 'scroll' ? handleWheel : undefined}
     >
-      {places.map((place, i) => (
-        <Card
-          key={i}
-          title={place.title}
-          category={place.category}
-          tags={place.tags}
-          liked={place.liked}
-          image={place.image}
-          variant={variant}
-        />
-      ))}
+      {places.map((place, i) => {
+        const card = (
+          <Card
+            title={place.title}
+            category={place.category}
+            tags={place.tags}
+            liked={place.liked}
+            image={place.image}
+            variant={variant}
+          />
+        );
+        const to = place.to ?? (place.id != null ? `/place/${place.id}` : null);
+
+        return to ? (
+          <Link
+            key={place.id ?? i}
+            to={to}
+            className="block shrink-0 cursor-pointer"
+          >
+            {card}
+          </Link>
+        ) : (
+          <div key={place.id ?? i} className="shrink-0">
+            {card}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/favorites/AddCollectionModal.jsx
+++ b/src/components/favorites/AddCollectionModal.jsx
@@ -17,7 +17,7 @@ export default function AddCollectionModal({ open, onClose, onSubmit }) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 grid place-items-center bg-black/40">
+    <div className="fixed inset-0 z-[200] grid place-items-center bg-black/40">
       <div className="w-[90%] max-w-sm rounded-xl bg-white p-5 shadow-xl">
         {/* 헤더 */}
         <div className="mb-3 flex items-center justify-between">

--- a/src/components/favorites/FavoritesPickerSheet.jsx.jsx
+++ b/src/components/favorites/FavoritesPickerSheet.jsx.jsx
@@ -1,0 +1,110 @@
+import { X, Plus, Check } from 'lucide-react';
+
+export default function FavoritesPickerSheet({
+  open,
+  onClose,
+  collections = [],
+  selectedIds = [],
+  onToggle,          // (id) => void
+  onCreateNew,       // () => void
+  onSave,            // () => void
+}) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-end justify-center">
+      {/* dim */}
+      <button
+        aria-label="닫기"
+        onClick={onClose}
+        className="absolute inset-0 z-0 bg-black/30"
+      />
+      {/* sheet */}
+      <div className="
+          relative z-10 mt-0 w-full
+          max-w-[400px] min-w-[360px]  /* Layout과 유사한 폭 */
+          rounded-t-[20px] bg-white shadow-[0_-8px_24px_rgba(0,0,0,0.12)]
+          overflow-hidden
+        "
+      >
+        {/* 헤더 */}
+        <div className="flex items-center justify-between border-b border-gray-100 px-5 py-3">
+          <h3 className="text-[15px] font-semibold text-[#1B2340]">
+            찜할 보석함 선택
+          </h3>
+          <button
+            aria-label="닫기"
+            onClick={onClose}
+            className="rounded-full p-1 text-gray-500 hover:bg-gray-100"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="max-h-[60vh] overflow-y-auto px-5 py-3">
+          {/* 새 보석함 만들기 */}
+          <button
+            onClick={onCreateNew}
+            className="
+              mb-2 flex w-full items-center gap-2 rounded-lg border border-gray-200
+              bg-white px-3 py-2 text-left text-[14px] text-[#1B2340]
+              hover:bg-gray-50
+            "
+          >
+            <span className="grid h-6 w-6 place-items-center rounded-full bg-gray-100">
+              <Plus size={14} />
+            </span>
+            새 돌멩이 보석함 만들기
+          </button>
+
+          {/* 보석함 리스트 */}
+          <ul className="divide-y divide-gray-100">
+            {collections.map((c) => {
+              const checked = selectedIds.includes(c.id);
+              return (
+                <li key={c.id}>
+                  <button
+                    onClick={() => onToggle?.(c.id)}
+                    className="flex w-full items-center justify-between py-3"
+                  >
+                    <div className="flex items-center gap-3">
+                      {/* 선택 원형 토글 */}
+                      <span
+                        className={[
+                          "grid h-6 w-6 place-items-center rounded-full border",
+                          checked
+                            ? "border-[#3C4462] bg-[#3C4462]"
+                            : "border-gray-300 bg-white",
+                        ].join(" ")}
+                      >
+                        {checked ? <Check size={14} className="text-white" /> : null}
+                      </span>
+                      <div className="text-left">
+                        <div className="text-[14px] text-[#1B2340]">{c.title}</div>
+                        {typeof c.count === "number" ? (
+                          <div className="text-[11px] text-gray-500">
+                            포함된 장소 {c.count}개
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        {/* 하단 고정 저장 버튼 (safe-area 대응) */}
+        <div className="sticky bottom-0 bg-white px-5 pb-[env(safe-area-inset-bottom)] pt-3">
+          <button
+            onClick={onSave}
+            className="mb-3 w-full rounded-lg bg-[#3C4462] py-2 text-[14px] font-semibold text-white"
+          >
+            저장
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/place/BackBar.jsx
+++ b/src/components/place/BackBar.jsx
@@ -1,0 +1,19 @@
+import { ChevronLeft, Heart } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+
+export default function BackBar({ onToggleLike, liked=false }) {
+  const nav = useNavigate();
+  return (
+    <div className="h-20 bg-[#E9E9EC] px-4 flex items-end pb-2">
+      <button
+        aria-label="뒤로가기"
+        onClick={() => nav(-1)}
+        className="mr-2 p-1 -ml-1"
+      >
+        <ChevronLeft size={22} className="text-[#1B2340]" />
+      </button>
+      <span className="text-[15px] text-[#1B2340]">가게 사진</span>
+      
+    </div>
+  );
+}

--- a/src/components/place/MenuSkeleton.jsx
+++ b/src/components/place/MenuSkeleton.jsx
@@ -1,0 +1,10 @@
+export default function MenuSkeleton({ label = '바나나 푸딩' }) {
+  return (
+    <div className="shrink-0 w-[72px]">
+      <div className="w-[72px] h-[108px] rounded-[10px] bg-gray-200" />
+      <p className="mt-2 text-[12px] leading-[14px] text-gray-600 truncate text-center">
+        {label}
+      </p>
+    </div>
+  );
+}

--- a/src/components/place/ReviewCard.jsx
+++ b/src/components/place/ReviewCard.jsx
@@ -1,0 +1,28 @@
+// src/components/place/ReviewCard.jsx
+export default function ReviewCard({ title, badges = [], text }) {
+  return (
+    <div className="w-[168px] shrink-0 rounded-xl border border-[#F0E8D5] bg-[#FBF8F1] p-4">
+      <div className="flex items-center gap-2">
+        <div className="grid h-8 w-8 place-items-center rounded-full bg-gray-200 text-[10px] text-gray-500">
+          img
+        </div>
+        <div className="text-[13px] font-semibold leading-none">{title}</div>
+      </div>
+
+      <div className="mt-2 flex flex-wrap gap-1">
+        {badges.map((b) => (
+          <span
+            key={b}
+            className="rounded-full border border-gray-200 bg-white px-2 py-[2px] text-[10px] text-gray-600"
+          >
+            {b}
+          </span>
+        ))}
+      </div>
+
+      <div className="mt-3 rounded-lg bg-white p-3 text-[12px] leading-5 text-gray-700">
+        {text}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/favoritesStorage.js
+++ b/src/lib/favoritesStorage.js
@@ -1,0 +1,63 @@
+// 키 한 곳에서 관리
+const K = {
+  collections: 'fav_collections',      // [{id, title, description, count}]
+  mapping: 'fav_mapping',              // { [placeId]: number[] }  (보석함 id 배열)
+};
+
+// 기본 보석함 샘플 (최초 1회)
+const DEFAULT_COLLECTIONS = [
+  { id: 1, title: '카공하기 좋은 곳', description: '', count: 3 },
+  { id: 2, title: '빙수 맛있는 곳',   description: '', count: 2 },
+];
+
+export function loadCollections() {
+  const raw = localStorage.getItem(K.collections);
+  if (!raw) {
+    localStorage.setItem(K.collections, JSON.stringify(DEFAULT_COLLECTIONS));
+    return [...DEFAULT_COLLECTIONS];
+  }
+  try { return JSON.parse(raw) || []; } catch { return []; }
+}
+
+export function saveCollections(list) {
+  localStorage.setItem(K.collections, JSON.stringify(list));
+}
+
+export function loadMapping() {
+  const raw = localStorage.getItem(K.mapping);
+  try { return raw ? JSON.parse(raw) : {}; } catch { return {}; }
+}
+
+export function saveMapping(map) {
+  localStorage.setItem(K.mapping, JSON.stringify(map));
+}
+
+// placeId 를 보석함들에 저장/해제 토글
+export function togglePlaceInCollection(placeId, collectionId) {
+  const map = loadMapping();
+  const set = new Set(map[placeId] || []);
+  set.has(collectionId) ? set.delete(collectionId) : set.add(collectionId);
+  map[placeId] = Array.from(set);
+  saveMapping(map);
+  return map[placeId];
+}
+
+// 보석함 추가
+export function addCollection({ title, description }) {
+  const list = loadCollections();
+  const newItem = { id: Date.now(), title, description: description || '', count: 0 };
+  const next = [...list, newItem];
+  saveCollections(next);
+  return newItem;
+}
+
+// 보석함별 포함 개수 재계산(카운트 싱크)
+export function recountCollectionCounts() {
+  const list = loadCollections();
+  const map = loadMapping();
+  const counter = {};
+  Object.values(map).forEach(ids => (ids || []).forEach(id => { counter[id] = (counter[id] || 0) + 1; }));
+  const next = list.map(c => ({ ...c, count: counter[c.id] || 0 }));
+  saveCollections(next);
+  return next;
+}

--- a/src/pages/Favorites.jsx
+++ b/src/pages/Favorites.jsx
@@ -1,25 +1,50 @@
-import { useState } from "react";
+// src/pages/Favorites.jsx
+import { useEffect, useState } from "react";
 import { Heart, Plus, Pencil } from "lucide-react";
+import { useSearchParams, useNavigate } from "react-router-dom";
 import CollectionCard from "../components/favorites/CollectionCard";
 import AddCollectionModal from "../components/favorites/AddCollectionModal";
 
+// storage 유틸 불러오기 (이름 겹치지 않도록 alias)
+import {
+  loadCollections,
+  recountCollectionCounts,
+  togglePlaceInCollection,
+  addCollection as addCollectionStorage,
+} from "../lib/favoritesStorage";
+
 export default function Favorites() {
-  // 초기 더미 데이터 (이름/카운트)
-  const [collections, setCollections] = useState([
-    { id: 1, title: "카공하기 좋은 곳", count: 3 },
-    { id: 2, title: "빙수 맛있는 곳", count: 2 },
-    { id: 3, title: "카공하기 좋은 곳", count: 0 },
-    { id: 4, title: "빙수 맛있는 곳", count: 0 },
-  ]);
-
+  const [collections, setCollections] = useState(() => recountCollectionCounts());
   const [openAdd, setOpenAdd] = useState(false);
+  const [pendingPlaceId, setPendingPlaceId] = useState(null); // 상세에서 넘어온 placeId
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
 
-  const addCollection = ({ title, description }) => {
-    setCollections((prev) => [
-      ...prev,
-      { id: Date.now(), title, description, count: 0 },
-    ]);
+  // 쿼리로 들어오면 모달 자동 오픈
+  useEffect(() => {
+    const needCreate = searchParams.get("create") === "1";
+    const pid = Number(searchParams.get("placeId"));
+    if (needCreate) {
+      if (!Number.isNaN(pid)) setPendingPlaceId(pid);
+      setOpenAdd(true);
+    }
+  }, [searchParams]);
+
+  // 초기에 localStorage 동기화(혹시 모를 mismatch 보정)
+  useEffect(() => {
+    setCollections(recountCollectionCounts());
+  }, []);
+
+  // 새 보석함 생성 + (옵션) 해당 place 자동 추가
+  const handleAddCollection = ({ title, description }) => {
+    const created = addCollectionStorage({ title, description }); // 로컬에 생성
+    if (pendingPlaceId) {
+      togglePlaceInCollection(created.id, pendingPlaceId);       // 새 보석함에 장소 담기
+    }
+    setCollections(recountCollectionCounts());                   // 카운트 갱신
     setOpenAdd(false);
+    setPendingPlaceId(null);
+    navigate("/favorites", { replace: true });                   // 쿼리 제거 (새로고침해도 모달 안뜸)
   };
 
   return (
@@ -27,9 +52,7 @@ export default function Favorites() {
       {/* 상단 네이비 헤더 */}
       <header className="bg-[#1B2340] h-36 rounded-b-2xl flex items-center justify-center text-white">
         <div className="w-full px-5">
-          <h1 className="text-[18px] font-semibold text-center">
-            내가 찜한 돌멩이 보석함
-          </h1>
+          <h1 className="text-[18px] font-semibold text-center">내가 찜한 돌멩이 보석함</h1>
         </div>
       </header>
 
@@ -40,14 +63,12 @@ export default function Favorites() {
             <Heart size={14} className="text-[#3C4462]" />
             찜 기반 추천받기
           </button>
-
           <button className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-700">
             <Pencil size={14} />
             편집
           </button>
-
           <button
-            onClick={() => setOpenAdd(true)}
+            onClick={() => { setPendingPlaceId(null); setOpenAdd(true); }} // 찜 화면에서 직접 추가
             className="ml-auto inline-flex items-center gap-1 rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-700"
           >
             <Plus size={14} />
@@ -73,8 +94,12 @@ export default function Favorites() {
       {/* 새 보석함 추가 모달 */}
       <AddCollectionModal
         open={openAdd}
-        onClose={() => setOpenAdd(false)}
-        onSubmit={addCollection}
+        onClose={() => {
+          setOpenAdd(false);
+          setPendingPlaceId(null);
+          navigate("/favorites", { replace: true });
+        }}
+        onSubmit={handleAddCollection}
       />
     </div>
   );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import OnboardingFlow from '../components/Onboarding/OnboardingFlow';
 import LocationBar from '../components/home/LocationBar';
 import SearchBar from '../components/common/SearchBar';
@@ -6,6 +7,7 @@ import StampCard from '../components/home/StampCard';
 import SectionTitle from '../components/home/SectionTitle';
 import PlaceCards from '../components/common/PlaceCards';
 import TagPills from '../components/common/TagPills';
+
 
 const Home = () => {
   const [needsOnboarding, setNeedsOnboarding] = useState(() => {
@@ -15,16 +17,16 @@ const Home = () => {
 
   // 데이터 정의
   const favoriteData = [
-    { title: '어나더굿뉴스', category: '카페', tags: ['커피', '디저트'] },
-    { title: '슬로카페달팽이', category: '카페', tags: ['브런치'] },
-    { title: '모던플레이스', category: '레스토랑', tags: ['파스타', '분위기'] },
-    { title: '모던플레이스', category: '레스토랑', tags: ['파스타', '분위기'] },
+    { id: 1, title: '어나더굿뉴스', category: '카페', tags: ['커피', '디저트'] },
+    { id: 2, title: '슬로카페달팽이', category: '카페', tags: ['브런치'] },
+    { id: 3, title: '모던플레이스', category: '레스토랑', tags: ['파스타', '분위기'] },
+    { id: 4, title: '모던플레이스', category: '레스토랑', tags: ['파스타', '분위기'] },
   ];
 
   const todayData = [
-    { title: '슬로카페달팽이', category: '카페', tags: ['브런치'] },
-    { title: '모던플레이스', category: '레스토랑', tags: ['파스타'] },
-    { title: '브루클린카페', category: '카페', tags: ['분위기'] }
+    { id: 101, title: '슬로카페달팽이', category: '카페', tags: ['브런치'] },
+    { id: 102, title: '모던플레이스', category: '레스토랑', tags: ['파스타'] },
+    { id: 103, title: '브루클린카페', category: '카페', tags: ['분위기'] }
   ];
 
   const handleOnboardingComplete = userData => {
@@ -72,7 +74,7 @@ const Home = () => {
 
         {/* 3열 카드 그리드 (칸 간격 12px) */}
         <PlaceCards 
-          places={todayData}
+          places={todayData} 
           variant="compact"
           layout="grid"
           className="mt-[12px]"

--- a/src/pages/PlaceDetail.jsx
+++ b/src/pages/PlaceDetail.jsx
@@ -1,0 +1,193 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { Heart, MapPin } from 'lucide-react';
+import { useRef, useMemo, useState, useEffect } from 'react';
+
+import BackBar from '../components/place/BackBar.jsx';
+import TagPills from '../components/common/TagPills.jsx';
+import ReviewCard from '../components/place/ReviewCard.jsx';
+import MenuSkeleton from '../components/place/MenuSkeleton.jsx';
+
+import FavoritesPickerSheet from '../components/favorites/FavoritesPickerSheet.jsx';
+import AddCollectionModal from '../components/favorites/AddCollectionModal.jsx'; // ✅ 모달 임포트
+import {
+  loadCollections, recountCollectionCounts,
+  loadMapping, togglePlaceInCollection, addCollection
+} from '../lib/favoritesStorage.js';
+
+const MOCK = {
+  name: '카페 기웃기웃',
+  distance: '내 위치에서 234m',
+  tags: ['달달한', '메뉴가 다양한', '조용한'],
+  desc:
+    '이 가게는 회원님의 취향인 분위기와 달달한 맛에 적합하며 최애 장소로 입력해 주신 밀리커피와 메뉴가 다양하다는 공통점이 있습니다.',
+  menu: ['바나나 푸딩', '아메리카노', '바나나라떼', '바나나브레드', '바나나쉐이크'],
+  reviews: [
+    { id: 1, title: '장꾸 돌멩이', badges: ['맛있는', '내부좌석 편안', '조용함'], text: '사장님이 친절하고 커피가 맛있어요' },
+    { id: 2, title: '장꾸 돌멩이', badges: ['맛있는', '내부좌석 편안', '조용함'], text: '사장님이 친절하고 커피가 맛있어요' },
+    { id: 3, title: '장꾸 돌멩이', badges: ['맛있는', '내부좌석 편안', '조용함'], text: '사장님이 친절하고 커피가 맛있어요' },
+  ],
+};
+
+export default function PlaceDetail() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const placeId = useMemo(() => String(id || 'demo-1'), [id]);
+
+  // 바텀시트 상태
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [collections, setCollections] = useState(() => loadCollections());
+  const [selected, setSelected] = useState([]);
+
+  const [addOpen, setAddOpen] = useState(false);
+
+  // 현재 placeId가 포함된 보석함 미리 체크
+  useEffect(() => {
+    const m = loadMapping();
+    setSelected(m[placeId] || []);
+  }, [placeId]);
+
+  const toggleSelect = (cid) =>
+    setSelected(prev => prev.includes(cid) ? prev.filter(v => v !== cid) : [...prev, cid]);
+
+  const handleSaveFavorites = () => {
+    // 선택된 보석함들로 동기화(간단 토글 방식)
+    const before = new Set(loadMapping()[placeId] || []);
+    const after  = new Set(selected);
+
+    // 제거
+    before.forEach(cid => { if (!after.has(cid)) togglePlaceInCollection(placeId, cid); });
+    // 추가
+    after.forEach(cid => { if (!before.has(cid)) togglePlaceInCollection(placeId, cid); });
+
+    setCollections(recountCollectionCounts()); // 카운트 재계산
+    setSheetOpen(false);
+  };
+
+  // 바텀시트에서 "새 보석함" 클릭 → 모달 열기
+  const handleCreateNew = () => setAddOpen(true);
+
+  // 모달에서 "추가하기" 제출 → 보석함 생성 + 현재 가게 자동담기 + 체크 반영
+  const handleSubmitNewCollection = ({ title, description }) => {
+    if (!title?.trim()) return;
+    const newC = addCollection({ title: title.trim(), description: description?.trim() });
+
+    // 방금 만든 보석함에 현재 place 담기
+    togglePlaceInCollection(placeId, newC.id);
+
+    // 체크 상태/카운트 갱신
+    setSelected(prev => (prev.includes(newC.id) ? prev : [...prev, newC.id]));
+    setCollections(recountCollectionCounts());
+
+    // 모달만 닫고(시트는 열어둬도 됨)
+    setAddOpen(false);
+  };
+
+
+  // 가로 휠 스크롤 핸들러
+  const toHorizontal = (ref) => (e) => {
+    if (!ref.current) return;
+    if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+      e.preventDefault();
+      ref.current.scrollLeft += e.deltaY;
+    }
+  };
+  const menuRef = useRef(null);
+  const reviewsRef = useRef(null);
+
+  return (
+    <div className="min-h-screen bg-white">
+      {/* 상단 이미지 영역 (하트 없음) */}
+      <div className="relative z-0 h-[120px] w-full bg-gray-200">
+        <BackBar title="가게 사진" />
+      </div>
+
+      {/* 흰 컨테이너 */}
+      <div className="relative -mt-5 rounded-t-[28px] bg-white overflow-hidden shadow-[0_-8px_24px_rgba(0,0,0,0.06)]">
+        {/* 태그 */}
+        <div className="px-5 pt-4">
+          <TagPills tags={MOCK.tags} variant="outline-navy" />
+        </div>
+
+        {/* 타이틀 + 아이콘 (오른쪽: 지도, 하트 순서) */}
+        <div className="px-5 mt-3 flex items-start justify-between">
+          <div>
+            <h1 className="text-[22px] font-semibold tracking-tight text-[#1B2340]">{MOCK.name}</h1>
+            <p className="mt-1 text-[12px] text-gray-600">{MOCK.distance}</p>
+          </div>
+          <div className="flex gap-3">
+            <button
+              aria-label="지도"
+              className="grid h-9 w-9 place-items-center rounded-full border border-gray-200 bg-white text-[#1B2340]"
+            >
+              <MapPin size={18} />
+            </button>
+            <button
+              aria-label="찜"
+              onClick={() => setSheetOpen(true)}
+              className="grid h-9 w-9 place-items-center rounded-full border border-gray-200 bg-white text-[#1B2340]"
+            >
+              <Heart size={18} />
+            </button>
+          </div>
+        </div>
+
+        {/* 설명 */}
+        <div className="px-5 mt-3 pb-4 border-b border-gray-100">
+          <p className="text-[13px] leading-5 text-gray-700">
+            이 가게는 회원님의 취향인 <span className="text-[#E9A94A]">분위기</span>와
+            <span className="text-[#E9A94A]"> 달달한</span> 맛에 적합하며 최애 장소로 입력해 주신
+            <span className="text-[#E9A94A]"> 밀리커피</span>와 메뉴가 다양하다는 공통점이 있습니다.
+          </p>
+        </div>
+
+        {/* 메뉴 (가로 스크롤) */}
+        <section className="px-5 py-4">
+          <h2 className="text-[16px] font-semibold text-[#1B2340]">메뉴</h2>
+          <div
+            ref={menuRef}
+            onWheel={toHorizontal(menuRef)}
+            className="mt-3 flex gap-3 overflow-x-auto scrollbar-hide -mx-5 px-5 snap-x snap-mandatory"
+          >
+            {MOCK.menu.map((m, i) => (
+              <div key={i} className="snap-start shrink-0">
+                <MenuSkeleton label={m} />
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* 후기 (가로 스크롤) */}
+        <section className="px-5 pb-6">
+          <h2 className="text-[16px] font-semibold text-[#1B2340]">내 주변 돌멩이 수집가들의 후기</h2>
+          <div
+            ref={reviewsRef}
+            onWheel={toHorizontal(reviewsRef)}
+            className="mt-3 flex gap-3 overflow-x-auto scrollbar-hide -mx-5 px-5"
+          >
+            {MOCK.reviews.map(r => (
+              <ReviewCard key={r.id} title={r.title} badges={r.badges} text={r.text} />
+            ))}
+          </div>
+        </section>
+      </div>
+
+      {/* 바텀시트 (보석함 선택) */}
+      <FavoritesPickerSheet
+        open={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        collections={collections}
+        selectedIds={selected}
+        onToggle={toggleSelect}
+        onCreateNew={handleCreateNew}        //  새 보석함 → 모달 오픈
+        onSave={handleSaveFavorites}
+      />
+
+      {/* 새 보석함 모달 (팝업) — 디자인 스샷처럼 오버레이로 뜸 */}
+      <AddCollectionModal
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        onSubmit={handleSubmitNewCollection} // 보석함 생성 + 현재 가게 자동 저장
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
상세페이지 구현 및 찜 보관함 기능 추가.
상세페이지에서 찜(하트) 클릭 시 보석함 선택 BottomSheet를 띄우고, 새 보석함 생성 모달을 통해 보석함을 만들면 해당 보석함에 현재 장소가 자동 추가되도록 구현했습니다. 또한 오버레이/레이어(z-index) 이슈와 하단 네비게이션 탭 아이콘 오타를 수정했습니다.

## Changes
- `PlaceDetail`에 찜 플로우 연동 (BottomSheet 열기/선택/저장)
- `FavoritesPickerSheet` 컴포넌트 구현 (선택/체크 UI, 저장 버튼 고정)
- `AddCollectionModal`에서 생성 시 **현재 장소 자동 추가**
-  즐겨찾기 로컬 스토리지 유틸 (`favoritesStorage.js`) 연동: 로드/토글/카운트 재계산
-  시트/모달 **z-index 및 오버레이** 정리 (화면 최상단에 안정적으로 표시)

## Test plan
- [ ] 상세페이지 진입 → 우상단 **하트** 클릭 시 보석함 선택 BottomSheet가 뜨는지 확인
- [ ] 보석함 하나 이상 선택 후 **저장** → `Favorites` 화면에서 카운트 증가 확인
- [ ] **새 보석함 만들기** → 이름 입력 후 생성하면 해당 보석함이 **자동 선택**되고 저장 시 카운트 1 증가 확인
- [ ] 시트 및 모달이 다른 UI 뒤로 숨지 않고 **항상 맨 위**에 뜨는지 확인(z-index 동작)
- [ ] 하단 탭 아이콘(커뮤니티/내 정보)이 상세페이지에서도 정상 표시되는지 확인
- [ ] 새로고침 이후에도 보석함/매핑 데이터가 **유지**되는지(localStorage) 확인
- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 에러 없음 확인
- [ ] 반응형 디자인 확인 (모바일/데스크톱)

## Additional Notes
- 추후: `Favorites` 편집 모드(이름 변경/삭제/정렬), 보석함 상세(장소 리스트) 라우팅 예정
- 실제 API 연동 시, 로컬 스토리지 유틸을 서버 API 호출로 대체(또는 동기화) 필요